### PR TITLE
Assets实现flavor分化及其它一些优化

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -409,6 +409,21 @@ android {
 
     }
 
+    sourceSets {
+        // @Hint by LZX284 on Nov 15, 2023.
+        //  ! The assets file is divided into three directories according to different flavors.
+        //  ! But the files are not actually moved to avoid conflicts with the latest modifications.
+        getByName("main"){
+            assets.srcDirs("src/main/assets")
+        }
+        getByName(flavorNameApp){
+            assets.srcDirs("src/main/assets_$flavorNameApp")
+        }
+        getByName(flavorNameInrt){
+            assets.srcDirs("src/main/assets_$flavorNameInrt")
+        }
+    }
+
     compileOptions {
         isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = versions.javaVersion


### PR DESCRIPTION
因同步最新修改时存在冲突，因此作了一些调整……
@SuperMonster003 
先就这样吧，Assets目录分化设置先保留，文件未移动，不会对目前的打包功能产生实际影响。至于是否采用，你可以按自己的偏好进行选择