### PR TITLE
打包功能优化

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,1 +1,3 @@
 /build
+/app
+/inrt

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -263,6 +263,11 @@ dependencies /* MLKit */ {
     implementation("com.google.mlkit:barcode-scanning:17.2.0")
 }
 
+dependencies /* openCC */ {
+    // openCC
+    implementation("com.github.qichuan:android-opencc:1.2.0")
+}
+
 dependencies /* Auto.js Extensions */ {
     // Settings Compat
     // @Integrated by SuperMonster003 on Mar 30, 2023.
@@ -361,6 +366,7 @@ android {
                     "icon" to "@mipmap/ic_launcher",
                 )
             )
+            ndk.abiFilters.addAll(listOf("")) // No ABI files is needed.
 
             gradle.taskGraph.whenReady(object : Action<TaskExecutionGraph> {
                 override fun execute(taskGraph: TaskExecutionGraph) {
@@ -407,21 +413,6 @@ android {
             }
         }
 
-    }
-
-    sourceSets {
-        // @Hint by LZX284 on Nov 15, 2023.
-        //  ! The assets file is divided into three directories according to different flavors.
-        //  ! But the files are not actually moved to avoid conflicts with the latest modifications.
-        getByName("main"){
-            assets.srcDirs("src/main/assets")
-        }
-        getByName(flavorNameApp){
-            assets.srcDirs("src/main/assets_$flavorNameApp")
-        }
-        getByName(flavorNameInrt){
-            assets.srcDirs("src/main/assets_$flavorNameInrt")
-        }
     }
 
     compileOptions {

--- a/app/src/main/java/org/autojs/autojs/runtime/api/AppUtils.kt
+++ b/app/src/main/java/org/autojs/autojs/runtime/api/AppUtils.kt
@@ -227,10 +227,12 @@ class AppUtils {
         }
 
         @JvmStatic
-        fun isBroadcastShortForm(s: String) = BroadcastShortForm.entries.any { it.shortName.contentEquals(s) }
+//        fun isBroadcastShortForm(s: String) = BroadcastShortForm.entries.any { it.shortName.contentEquals(s) }
+        fun isBroadcastShortForm(s: String) = BroadcastShortForm.values().any { it.shortName.contentEquals(s) }
 
         @JvmStatic
-        fun isActivityShortForm(s: String) = ActivityShortForm.entries.any { it.shortName.contentEquals(s) }
+//        fun isActivityShortForm(s: String) = ActivityShortForm.entries.any { it.shortName.contentEquals(s) }
+        fun isActivityShortForm(s: String) = ActivityShortForm.values().any { it.shortName.contentEquals(s) }
 
         fun getInstalledApplications(context: Context): List<ApplicationInfo> = context.packageManager.let {
             when {

--- a/app/src/main/java/org/autojs/autojs/runtime/api/Floaty.kt
+++ b/app/src/main/java/org/autojs/autojs/runtime/api/Floaty.kt
@@ -19,7 +19,8 @@ import org.autojs.autojs.ui.enhancedfloaty.FloatyService
 import org.autojs.autojs.util.ViewUtils.setViewMeasure
 import org.autojs.autojs6.R
 import java.util.concurrent.CopyOnWriteArraySet
-import kotlin.concurrent.Volatile
+//import kotlin.concurrent.Volatile
+import kotlin.jvm.Volatile
 
 /**
  * Created by Stardust on 2017/12/5.

--- a/app/src/main/java/org/autojs/autojs/ui/settings/AppLanguagePreference.kt
+++ b/app/src/main/java/org/autojs/autojs/ui/settings/AppLanguagePreference.kt
@@ -30,7 +30,8 @@ class AppLanguagePreference : MaterialListPreference {
 
     override fun onChangeConfirmed(dialog: MaterialDialog) {
         super.onChangeConfirmed(dialog)
-        Language.entries.find {
+//        Language.entries.find {
+        Language.values().find {
             it.getEntryName(prefContext) == dialog.items?.get(dialog.selectedIndex)
         }?.let {
             GlobalAppContext.post {


### PR DESCRIPTION
1. 精简打包模板体积（assets的flavors分化暂时可以不用，然后精简了lib目录，以自己的方法实现的）
2. 一些类中kotlin 1.9版特有的写法暂时改成兼容1.8版的，避免命令行编译出错
3. 引入openCC依赖