### PR TITLE
解决工程型代码打包的 apk 安装后无法运行的问题。

### DIFF
--- a/app/src/main/java/org/autojs/autojs/ui/project/BuildActivity.java
+++ b/app/src/main/java/org/autojs/autojs/ui/project/BuildActivity.java
@@ -423,7 +423,9 @@ public class BuildActivity extends BaseActivity implements ApkBuilder.ProgressCa
 
     private ApkBuilder.AppConfig createAppConfig() {
         if (mProjectConfig != null) {
-            return ApkBuilder.AppConfig.fromProjectConfig(mSource, mProjectConfig);
+            return ApkBuilder.AppConfig.fromProjectConfig(mSource, mProjectConfig)
+                    .setAbis(getSelectedAbis())
+                    .setLibs(getSelectedLibs());
         }
         String jsPath = mSourcePath.getText().toString();
         String versionName = mVersionName.getText().toString();
@@ -431,6 +433,18 @@ public class BuildActivity extends BaseActivity implements ApkBuilder.ProgressCa
         String appName = mAppName.getText().toString();
         String packageName = mPackageName.getText().toString();
 
+        return new ApkBuilder.AppConfig()
+                .setAppName(appName)
+                .setSourcePath(jsPath)
+                .setPackageName(packageName)
+                .setVersionName(versionName)
+                .setVersionCode(versionCode)
+                .setAbis(getSelectedAbis())
+                .setLibs(getSelectedLibs())
+                .setIcon(mIsDefaultIcon ? null : () -> BitmapUtils.drawableToBitmap(mIcon.getDrawable()));
+    }
+
+    private ArrayList<String> getSelectedAbis() {
         ArrayList<String> abis = new ArrayList<>();
 
         for (int i = 0; i < mFlexboxAbis.getChildCount(); i += 1) {
@@ -445,6 +459,10 @@ public class BuildActivity extends BaseActivity implements ApkBuilder.ProgressCa
             }
         }
 
+        return abis;
+    }
+
+    private ArrayList<String> getSelectedLibs() {
         ArrayList<String> libs = new ArrayList<>();
 
         for (int i = 0; i < mFlexboxLibs.getChildCount(); i += 1) {
@@ -459,15 +477,7 @@ public class BuildActivity extends BaseActivity implements ApkBuilder.ProgressCa
             }
         }
 
-        return new ApkBuilder.AppConfig()
-                .setAppName(appName)
-                .setSourcePath(jsPath)
-                .setPackageName(packageName)
-                .setVersionName(versionName)
-                .setVersionCode(versionCode)
-                .setAbis(abis)
-                .setLibs(libs)
-                .setIcon(mIsDefaultIcon ? null : () -> BitmapUtils.drawableToBitmap(mIcon.getDrawable()));
+        return libs;
     }
 
     private ApkBuilder callApkBuilder(File tmpDir, File outApk, ApkBuilder.AppConfig appConfig) throws Exception {


### PR DESCRIPTION
在 vscode 或在 app 中创建的工程，在 app 打包后运行直接闪退。但是 app 里创建的单文件打包后就能正常运行。用 logcat 抓闪退 apk 的日志发现闪退原因是缺少对应的 .so 文件。

```java
FATAL EXCEPTION: main (Ask Gemini)
Process: org.example.ttt, PID: 12260
java.lang.UnsatisfiedLinkError: dlopen failed: library "libjackpal-termexec2.so" not found
	at java.lang.Runtime.loadLibrary0(Runtime.java:1081)
	at java.lang.Runtime.loadLibrary0(Runtime.java:1003)
	at java.lang.System.loadLibrary(System.java:1765)
	at jackpal.androidterm.TermExec.<clinit>(TermExec.java:22)
	at jackpal.androidterm.ShellTermSession.createSubprocess(ShellTermSession.java:153)
	at jackpal.androidterm.ShellTermSession.initializeSession(ShellTermSession.java:101)
	at jackpal.androidterm.ShellTermSession.<init>(ShellTermSession.java:57)
	at org.autojs.autojs.runtime.api.Shell$MyShellTermSession.<init>(Shell.java:219)
	at org.autojs.autojs.runtime.api.Shell.lambda$init$0(Shell.java:100)
	at org.autojs.autojs.runtime.api.Shell.$r8$lambda$ZfzmJn7FBk93xEs5Am0lJscJHDc(Unknown Source:0)
	at org.autojs.autojs.runtime.api.Shell$$ExternalSyntheticLambda0.run(Unknown Source:4)
	at android.os.Handler.handleCallback(Handler.java:958)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:205)
	at android.os.Looper.loop(Looper.java:294)
	at android.app.ActivityThread.main(ActivityThread.java:8177)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971)
```

扒拉了一下源码，发现这里应该是打包时拷贝 .so 文件的逻辑。

https://github.com/SuperMonster003/AutoJs6/blob/c2f098019c4b541887c734a1568588f461f96367/app/src/main/java/org/autojs/autojs/apkbuilder/ApkBuilder.kt#L366-L377

然后顺着上面的函数一路找到了 AppConfig 的创建逻辑。

https://github.com/SuperMonster003/AutoJs6/blob/c2f098019c4b541887c734a1568588f461f96367/app/src/main/java/org/autojs/autojs/ui/project/BuildActivity.java#L424-L471

这里 425 行有个 if 语句，个人猜测是这里的判断导致工程型的代码和文件型的代码走了不同的 AppConfig 创建逻辑。也就是说因为工程型的代码的创建逻辑缺了参数导致打包时没有复制 .so 文件。解决了这个问题后我本地运行就没有问题了。