### PR TITLE
解除对 template.apk 的忽略

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ sync.ffs_db
 
 **/assets-app/declarations
 **/assets-app/sample/declarations
+
+# template apk
+!app/src/main/assets/template.apk


### PR DESCRIPTION
解决 #263。apk 是从 release 发布的 autojs apk 里解包的来的。