### PR TITLE
可以在project.json中使用权限的小写字符串配置打包的启用权限

### DIFF
--- a/app/src/main/java/org/autojs/autojs/ui/project/BuildActivity.java
+++ b/app/src/main/java/org/autojs/autojs/ui/project/BuildActivity.java
@@ -536,7 +536,12 @@ public class BuildActivity extends BaseActivity implements ApkBuilder.ProgressCa
             checkBox.setTextSize(12);
             int marginInPixels = (int) (8 * getResources().getDisplayMetrics().density);
             checkBox.setPadding(marginInPixels, 0, 0, 0);
-            checkBox.setChecked(false);
+            if (mProjectConfig != null) {
+                boolean checked = mProjectConfig.getPermissions().stream().anyMatch(p -> ("android.permission." + p.toUpperCase()).equals(permission));
+                checkBox.setChecked(checked);
+            } else {
+                checkBox.setChecked(false);
+            }
             mFlexboxPermissionsView.addView(checkBox);
         });
     }


### PR DESCRIPTION
例如在project.json中设置
```
"permissions": [
  "foreground_service",
  "manage_external_storage",
  "internet"
]
```
进入打包页面时会自动启用这几个权限，不用每次都手动勾选

![Screenshot_2025-05-19-09-37-43-432_org autojs autojs6](https://github.com/user-attachments/assets/3d50c1c7-ccde-4dc9-9240-d95c37beddb9)