### PR TITLE
适配 Android 12 及以上蓝牙权限模型变更

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -162,6 +162,10 @@
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
 
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+
     <uses-permission android:name="android.permission.SET_WALLPAPER" />
     <uses-permission android:name="android.permission.SET_WALLPAPER_HINTS" />
 

--- a/app/src/main/java/org/autojs/autojs/ui/project/BuildActivity.java
+++ b/app/src/main/java/org/autojs/autojs/ui/project/BuildActivity.java
@@ -141,6 +141,9 @@ public class BuildActivity extends BaseActivity implements ApkBuilder.ProgressCa
         put("android.permission.ACCESS_WIFI_STATE", R.string.text_permission_desc_access_wifi_state);
         put("android.permission.BLUETOOTH", R.string.text_permission_desc_bluetooth);
         put("android.permission.BLUETOOTH_ADMIN", R.string.text_permission_desc_bluetooth_admin);
+        put("android.permission.BLUETOOTH_CONNECT", R.string.text_permission_desc_bluetooth_connect);
+        put("android.permission.BLUETOOTH_SCAN", R.string.text_permission_desc_bluetooth_scan);
+        put("android.permission.BLUETOOTH_ADVERTISE", R.string.text_permission_desc_bluetooth_advertise);
         put("android.permission.BROADCAST_CLOSE_SYSTEM_DIALOGS", R.string.text_permission_desc_broadcast_close_system_dialogs);
         put("android.permission.CALL_PHONE", R.string.text_permission_desc_call_phone);
         put("android.permission.CAMERA", R.string.text_permission_desc_camera);

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -780,6 +780,9 @@
     <string name="text_permission_desc_billing">يسمح للتطبيق بإجراء عمليات الشراء داخل التطبيق</string>
     <string name="text_permission_desc_bluetooth">يسمح للتطبيق بالوصول إلى أجهزة Bluetooth</string>
     <string name="text_permission_desc_bluetooth_admin">يسمح للتطبيق بتهيئة أجهزة Bluetooth</string>
+    <string name="text_permission_desc_bluetooth_connect">السماح للتطبيق بالوصول إلى أجهزة Bluetooth وحالة الاتصال</string>
+    <string name="text_permission_desc_bluetooth_scan">السماح للتطبيق بالبحث عن أجهزة Bluetooth القريبة</string>
+    <string name="text_permission_desc_bluetooth_advertise">السماح للتطبيق بالإعلان عبر Bluetooth</string>
     <string name="text_permission_desc_broadcast_close_system_dialogs">يسمح للتطبيق بإرسال نية لإغلاق مربعات حوار النظام</string>
     <string name="text_permission_desc_call_phone">يسمح للتطبيق بإجراء مكالمات هاتفية</string>
     <string name="text_permission_desc_camera">يسمح للتطبيق بالوصول إلى الكاميرا</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -775,6 +775,9 @@
     <string name="text_permission_desc_billing">Allow the app to perform in-app purchases</string>
     <string name="text_permission_desc_bluetooth">Allow the app to access Bluetooth devices</string>
     <string name="text_permission_desc_bluetooth_admin">Allow the app to configure Bluetooth devices</string>
+    <string name="text_permission_desc_bluetooth_connect">Allow the app to access Bluetooth devices and connection state</string>
+    <string name="text_permission_desc_bluetooth_scan">Allow the app to scan for nearby Bluetooth devices</string>
+    <string name="text_permission_desc_bluetooth_advertise">Allow the app to advertise via Bluetooth</string>
     <string name="text_permission_desc_broadcast_close_system_dialogs">Allow the app to send an intent to close system dialogs</string>
     <string name="text_permission_desc_call_phone">Allow the app to make phone calls</string>
     <string name="text_permission_desc_camera">Allow the app to access the camera</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -778,6 +778,9 @@
     <string name="text_permission_desc_billing">Permitir que la aplicación realice compras dentro de la aplicación</string>
     <string name="text_permission_desc_bluetooth">Permitir que la aplicación acceda a dispositivos Bluetooth</string>
     <string name="text_permission_desc_bluetooth_admin">Permitir que la aplicación configure dispositivos Bluetooth</string>
+    <string name="text_permission_desc_bluetooth_connect">Permitir que la aplicación acceda a los dispositivos Bluetooth y al estado de conexión</string>
+    <string name="text_permission_desc_bluetooth_scan">Permitir que la aplicación busque dispositivos Bluetooth cercanos</string>
+    <string name="text_permission_desc_bluetooth_advertise">Permitir que la aplicación se anuncie mediante Bluetooth</string>
     <string name="text_permission_desc_broadcast_close_system_dialogs">Permitir que la aplicación envíe una intención para cerrar los cuadros de diálogo del sistema</string>
     <string name="text_permission_desc_call_phone">Permitir que la aplicación realice llamadas telefónicas</string>
     <string name="text_permission_desc_camera">Permitir que la aplicación acceda a la cámara</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -778,6 +778,9 @@
     <string name="text_permission_desc_billing">Autoriser l\'application à effectuer des achats intégrés</string>
     <string name="text_permission_desc_bluetooth">Autoriser l\'application à accéder aux périphériques Bluetooth</string>
     <string name="text_permission_desc_bluetooth_admin">Autoriser l\'application à configurer les périphériques Bluetooth</string>
+    <string name="text_permission_desc_bluetooth_connect">Autoriser l\'application à accéder aux périphériques et à l\'état de connexion Bluetooth</string>
+    <string name="text_permission_desc_bluetooth_scan">Autoriser l\'application à rechercher des périphériques Bluetooth à proximité</string>
+    <string name="text_permission_desc_bluetooth_advertise">Autoriser l\'application à se rendre visible via Bluetooth</string>
     <string name="text_permission_desc_broadcast_close_system_dialogs">Autoriser l\'application à envoyer une intention pour fermer les boîtes de dialogue système</string>
     <string name="text_permission_desc_call_phone">Autoriser l\'application à passer des appels téléphoniques</string>
     <string name="text_permission_desc_camera">Autoriser l\'application à accéder à la caméra</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -779,6 +779,9 @@
     <string name="text_permission_desc_billing">アプリがアプリ内購入を実行することを許可します</string>
     <string name="text_permission_desc_bluetooth">アプリが Bluetooth デバイスにアクセスすることを許可します</string>
     <string name="text_permission_desc_bluetooth_admin">アプリが Bluetooth デバイスを設定することを許可します</string>
+    <string name="text_permission_desc_bluetooth_connect">アプリが Bluetooth デバイスと接続状態にアクセスすることを許可します</string>
+    <string name="text_permission_desc_bluetooth_scan">アプリが近くの Bluetooth デバイスをスキャンすることを許可します</string>
+    <string name="text_permission_desc_bluetooth_advertise">アプリが Bluetooth でアドバタイズすることを許可します</string>
     <string name="text_permission_desc_broadcast_close_system_dialogs">アプリがシステムダイアログを閉じるためのインテントを送信することを許可します</string>
     <string name="text_permission_desc_call_phone">アプリが電話をかけることを許可します</string>
     <string name="text_permission_desc_camera">アプリがカメラにアクセスすることを許可します</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -780,6 +780,9 @@
     <string name="text_permission_desc_billing">앱이 인앱 구매를 수행하도록 허용합니다</string>
     <string name="text_permission_desc_bluetooth">앱이 블루투스 기기에 접근하도록 허용합니다</string>
     <string name="text_permission_desc_bluetooth_admin">앱이 블루투스 기기를 구성하도록 허용합니다</string>
+    <string name="text_permission_desc_bluetooth_connect">앱이 블루투스 장치 및 연결 상태에 접근하도록 허용합니다</string>
+    <string name="text_permission_desc_bluetooth_scan">앱이 근처 블루투스 장치를 검색하도록 허용합니다</string>
+    <string name="text_permission_desc_bluetooth_advertise">앱이 블루투스로 광고하도록 허용합니다</string>
     <string name="text_permission_desc_broadcast_close_system_dialogs">앱이 시스템 대화 상자를 닫기 위한 인텐트를 보내도록 허용합니다</string>
     <string name="text_permission_desc_call_phone">앱이 전화를 걸도록 허용합니다</string>
     <string name="text_permission_desc_camera">앱이 카메라에 접근하도록 허용합니다</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -778,6 +778,9 @@
     <string name="text_permission_desc_billing">Разрешить приложению выполнять покупки внутри приложения</string>
     <string name="text_permission_desc_bluetooth">Разрешить приложению доступ к устройствам Bluetooth</string>
     <string name="text_permission_desc_bluetooth_admin">Разрешить приложению настраивать устройства Bluetooth</string>
+    <string name="text_permission_desc_bluetooth_connect">Разрешить приложению доступ к устройствам Bluetooth и состоянию подключения</string>
+    <string name="text_permission_desc_bluetooth_scan">Разрешить приложению сканировать близлежащие устройства Bluetooth</string>
+    <string name="text_permission_desc_bluetooth_advertise">Разрешить приложению рекламировать себя через Bluetooth</string>
     <string name="text_permission_desc_broadcast_close_system_dialogs">Разрешить приложению отправлять намерение для закрытия системных диалогов</string>
     <string name="text_permission_desc_call_phone">Разрешить приложению совершать телефонные звонки</string>
     <string name="text_permission_desc_camera">Разрешить приложению доступ к камере</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -776,6 +776,9 @@
     <string name="text_permission_desc_billing">允許應用執行應用內購買</string>
     <string name="text_permission_desc_bluetooth">允許應用訪問藍牙設備</string>
     <string name="text_permission_desc_bluetooth_admin">允許應用配置藍牙設備</string>
+    <string name="text_permission_desc_bluetooth_connect">允許應用訪問藍牙設備及連接狀態</string>
+    <string name="text_permission_desc_bluetooth_scan">允許應用搜尋附近的藍牙設備</string>
+    <string name="text_permission_desc_bluetooth_advertise">允許應用透過藍牙廣播</string>
     <string name="text_permission_desc_broadcast_close_system_dialogs">允許應用發送一個意圖來關閉系統對話框</string>
     <string name="text_permission_desc_call_phone">允許應用撥打電話</string>
     <string name="text_permission_desc_camera">允許應用訪問相機</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -776,6 +776,9 @@
     <string name="text_permission_desc_billing">允許應用執行應用內購買</string>
     <string name="text_permission_desc_bluetooth">允許應用訪問藍牙設備</string>
     <string name="text_permission_desc_bluetooth_admin">允許應用配置藍牙設備</string>
+    <string name="text_permission_desc_bluetooth_connect">允許應用訪問藍牙設備及連接狀態</string>
+    <string name="text_permission_desc_bluetooth_scan">允許應用搜尋附近的藍牙設備</string>
+    <string name="text_permission_desc_bluetooth_advertise">允許應用透過藍牙廣播</string>
     <string name="text_permission_desc_broadcast_close_system_dialogs">允許應用發送一個意圖來關閉系統對話框</string>
     <string name="text_permission_desc_call_phone">允許應用撥打電話</string>
     <string name="text_permission_desc_camera">允許應用訪問相機</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -776,6 +776,9 @@
     <string name="text_permission_desc_billing">允许应用执行应用内购买</string>
     <string name="text_permission_desc_bluetooth">允许应用访问蓝牙设备</string>
     <string name="text_permission_desc_bluetooth_admin">允许应用配置蓝牙设备</string>
+    <string name="text_permission_desc_bluetooth_connect">允许应用访问蓝牙设备及连接状态</string>
+    <string name="text_permission_desc_bluetooth_scan">允许应用扫描附近的蓝牙设备</string>
+    <string name="text_permission_desc_bluetooth_advertise">允许应用通过蓝牙广播</string>
     <string name="text_permission_desc_broadcast_close_system_dialogs">允许应用发送一个意图来关闭系统对话框</string>
     <string name="text_permission_desc_call_phone">允许应用拨打电话</string>
     <string name="text_permission_desc_camera">允许应用访问相机</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1006,6 +1006,9 @@
     <string name="text_permission_desc_billing">Allow the app to perform in-app purchases</string>
     <string name="text_permission_desc_bluetooth">Allow the app to access Bluetooth devices</string>
     <string name="text_permission_desc_bluetooth_admin">Allow the app to configure Bluetooth devices</string>
+    <string name="text_permission_desc_bluetooth_connect">Allow the app to access Bluetooth devices and connection state</string>
+    <string name="text_permission_desc_bluetooth_scan">Allow the app to scan for nearby Bluetooth devices</string>
+    <string name="text_permission_desc_bluetooth_advertise">Allow the app to advertise via Bluetooth</string>
     <string name="text_permission_desc_broadcast_close_system_dialogs">Allow the app to send an intent to close system dialogs</string>
     <string name="text_permission_desc_call_phone">Allow the app to make phone calls</string>
     <string name="text_permission_desc_camera">Allow the app to access the camera</string>


### PR DESCRIPTION
## 问题

根据 <https://developer.android.com/develop/connectivity/bluetooth/bt-permissions>:

> If your app targets Android 12 (API level 31) or higher, declare the following permissions in your app's manifest file:

>- If your app looks for Bluetooth devices, such as BLE peripherals, declare the BLUETOOTH_SCAN permission.
>- If your app makes the current device discoverable to other Bluetooth devices, declare the BLUETOOTH_ADVERTISE permission.
>- If your app communicates with already-paired Bluetooth devices, declare the BLUETOOTH_CONNECT permission.

原本的 AutoJs6 在 manifest 中未声明 BLUETOOTH_CONNECT、BLUETOOTH_SCAN 与 BLUETOOTH_ADVERTISE 权限，故无法在 Android 12 及以上的装置使用需要该等权限的功能。

## 解决方案

在 manifest 中声明 BLUETOOTH_CONNECT、BLUETOOTH_SCAN 与 BLUETOOTH_ADVERTISE 权限以适配 Android 12 及以上蓝牙权限模型变更。

## 验证

在 Android 14 真机上测试，通过 runtime.requestPermissions 请求权限后可正常使用需要该等权限的功能。