### PR TITLE
feat(editor): 添加堆栈帧跳转功能

### DIFF
--- a/app/src/main/java/org/autojs/autojs/ui/edit/EditorMenu.java
+++ b/app/src/main/java/org/autojs/autojs/ui/edit/EditorMenu.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.text.InputType;
 import android.text.TextUtils;
 import android.view.MenuItem;
+import android.widget.Toast;
 import androidx.annotation.Nullable;
 import com.afollestad.materialdialogs.MaterialDialog;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -16,6 +17,7 @@ import org.autojs.autojs.model.indices.ClassSearchingItem;
 import org.autojs.autojs.script.JavaScriptFileSource;
 import org.autojs.autojs.ui.common.NotAskAgainDialog;
 import org.autojs.autojs.ui.edit.editor.CodeEditor;
+import org.autojs.autojs.ui.edit.editor.CodeEditor.StackFrame;
 import org.autojs.autojs.ui.main.scripts.EditableFileInfoDialogManager;
 import org.autojs.autojs.ui.project.BuildActivity;
 import org.autojs.autojs.util.ClipboardUtils;
@@ -90,6 +92,10 @@ public class EditorMenu {
         int itemId = item.getItemId();
         if (itemId == R.id.action_jump_to_line) {
             jumpToLine();
+            return true;
+        }
+        if (itemId == R.id.action_jump_to_error_line) {
+            jumpToErrorLine();
             return true;
         }
         if (itemId == R.id.action_jump_to_start) {
@@ -309,6 +315,19 @@ public class EditorMenu {
         mEditor.getLineCount()
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(this::showJumpDialog);
+    }
+
+    private void jumpToErrorLine() {
+        if (mEditor.hasErrorLine()) {
+            CodeEditor.StackFrame frame = mEditor.getNextStackFrame();
+            mEditor.jumpTo(frame.getLineNumber(), frame.getColumnNumber());
+            int total = mEditor.getStackFrameCount();
+            int current = mEditor.getCurrentStackIndex() + 1;
+            String info = mContext.getString(R.string.text_stack_frame_info, current, total, frame.getFunctionName(), frame.getLineNumber() + 1);
+            Toast.makeText(mContext, info, Toast.LENGTH_SHORT).show();
+        } else {
+            Toast.makeText(mContext, R.string.text_no_error_line, Toast.LENGTH_SHORT).show();
+        }
     }
 
     private void showJumpDialog(final int lineCount) {

--- a/app/src/main/java/org/autojs/autojs/ui/edit/EditorView.kt
+++ b/app/src/main/java/org/autojs/autojs/ui/edit/EditorView.kt
@@ -56,6 +56,7 @@ import org.autojs.autojs.ui.edit.completion.CodeCompletionBar.OnHintClickListene
 import org.autojs.autojs.ui.edit.debug.DebugBar
 import org.autojs.autojs.ui.edit.editor.CodeEditor
 import org.autojs.autojs.ui.edit.editor.CodeEditor.CheckedPatternSyntaxException
+import org.autojs.autojs.ui.edit.editor.CodeEditor.StackFrame
 import org.autojs.autojs.ui.edit.keyboard.FunctionsKeyboardHelper
 import org.autojs.autojs.ui.edit.keyboard.FunctionsKeyboardView
 import org.autojs.autojs.ui.edit.keyboard.FunctionsKeyboardView.ClickCallback
@@ -145,6 +146,9 @@ class EditorView : LinearLayout, OnHintClickListener, ClickCallback, ToolbarFrag
                 val msg = intent.getStringExtra(EXTRA_EXCEPTION_MESSAGE)
                 val line = intent.getIntExtra(EXTRA_EXCEPTION_LINE_NUMBER, -1)
                 val col = intent.getIntExtra(EXTRA_EXCEPTION_COLUMN_NUMBER, 0)
+                // Parse stack trace and set stack frames for navigation
+                val stackFrames = parseStackTrace(msg, line, col)
+                editor.setStackFrames(stackFrames)
                 if (line >= 1) {
                     editor.jumpTo(line - 1, col)
                 }
@@ -752,6 +756,52 @@ class EditorView : LinearLayout, OnHintClickListener, ClickCallback, ToolbarFrag
 
     fun cleanBeforeExit() {
         mTmpSavedFileForRunning?.deleteOnExit()
+    }
+
+    /**
+     * Parse stack trace from error message
+     * Rhino stack trace format: "at funcName (/path/file.js:line:col)" or "at /path/file.js:line:col"
+     */
+    private fun parseStackTrace(msg: String?, mainLine: Int, mainCol: Int): ArrayList<CodeEditor.StackFrame> {
+        val frames = ArrayList<CodeEditor.StackFrame>()
+        if (msg == null) {
+            if (mainLine >= 1) {
+                frames.add(CodeEditor.StackFrame("<error>", mainLine - 1, mainCol))
+            }
+            return frames
+        }
+
+        // Add main error line first (from RhinoException)
+        if (mainLine >= 1) {
+            frames.add(CodeEditor.StackFrame("<error>", mainLine - 1, mainCol))
+        }
+
+        // Parse stack frames: "at funcName (/path/file.js:line:col)" or "at /path/file.js:line:col"
+        // Pattern matches both formats
+        val stackPattern = Regex("""at\s+(?:(\w+)\s+)?\([^)]*?:(\d+):(\d+)\)|at\s+[^:]+:(\d+):(\d+)""")
+        stackPattern.findAll(msg).forEach { match ->
+            val (funcName, lineStr, colStr) = when {
+                match.groupValues[1] != "" -> Triple(
+                    match.groupValues[1],
+                    match.groupValues[2],
+                    match.groupValues[3]
+                )
+                match.groupValues[4] != "" -> Triple(
+                    "<anonymous>",
+                    match.groupValues[4],
+                    match.groupValues[5]
+                )
+                else -> return@forEach
+            }
+            val line = lineStr.toIntOrNull()?.minus(1) ?: return@forEach
+            val col = colStr.toIntOrNull() ?: 0
+            // Skip duplicate entries
+            if (frames.none { it.lineNumber == line && it.columnNumber == col }) {
+                frames.add(CodeEditor.StackFrame(funcName, line, col))
+            }
+        }
+
+        return frames
     }
 
     companion object {

--- a/app/src/main/java/org/autojs/autojs/ui/edit/editor/CodeEditor.kt
+++ b/app/src/main/java/org/autojs/autojs/ui/edit/editor/CodeEditor.kt
@@ -520,6 +520,45 @@ class CodeEditor : HVScrollView {
         var enabled = true
     }
 
+    /**
+     * Stack frame for error navigation
+     * Used to store function name, line number and column number of each call frame
+     */
+    data class StackFrame(
+        @JvmField val functionName: String,
+        @JvmField val lineNumber: Int,
+        @JvmField val columnNumber: Int
+    )
+
+    private val mStackFrames = ArrayList<StackFrame>()
+    private var mCurrentStackIndex = -1
+    private var mHasErrorLine = false
+
+    fun setStackFrames(frames: ArrayList<StackFrame>) {
+        mStackFrames.clear()
+        mStackFrames.addAll(frames)
+        mCurrentStackIndex = -1
+        mHasErrorLine = frames.isNotEmpty()
+    }
+
+    fun getNextStackFrame(): StackFrame? {
+        if (mStackFrames.isEmpty()) return null
+        mCurrentStackIndex = (mCurrentStackIndex + 1) % mStackFrames.size
+        return mStackFrames[mCurrentStackIndex]
+    }
+
+    fun getStackFrameCount(): Int = mStackFrames.size
+
+    fun getCurrentStackIndex(): Int = mCurrentStackIndex
+
+    fun hasErrorLine(): Boolean = mHasErrorLine
+
+    fun clearErrorLine() {
+        mStackFrames.clear()
+        mCurrentStackIndex = -1
+        mHasErrorLine = false
+    }
+
     class CheckedPatternSyntaxException(cause: PatternSyntaxException?) : Exception(cause)
 
     interface BreakpointChangeListener {

--- a/app/src/main/res/menu/menu_editor.xml
+++ b/app/src/main/res/menu/menu_editor.xml
@@ -68,6 +68,11 @@
                 app:showAsAction="never" />
 
             <item
+                android:id="@+id/action_jump_to_error_line"
+                android:title="@string/text_jump_to_error_line"
+                app:showAsAction="never" />
+
+            <item
                 android:id="@+id/action_jump_to_start"
                 android:title="@string/text_jump_to_start"
                 app:showAsAction="never" />

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -674,6 +674,9 @@
     <string name="text_jump_to_line">跳转到行</string>
     <string name="text_jump_to_line_end">跳转到行尾</string>
     <string name="text_jump_to_line_start">跳转到行首</string>
+    <string name="text_jump_to_error_line">跳转到出错行</string>
+    <string name="text_no_error_line">没有错误行</string>
+    <string name="text_stack_frame_info">堆栈 %1$d/%2$d: %3$s() 行 %4$d</string>
     <string name="text_jump_to_start">跳转到文件开始</string>
     <string name="text_keep_screen_on_when_in_foreground">前台时保持屏幕常亮</string>
     <string name="text_key_alias">别名</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -904,6 +904,9 @@
     <string name="text_jump_to_line">Jump to line</string>
     <string name="text_jump_to_line_end">Jump to line end</string>
     <string name="text_jump_to_line_start">Jump to line start</string>
+    <string name="text_jump_to_error_line">Jump to error line</string>
+    <string name="text_no_error_line">No error line</string>
+    <string name="text_stack_frame_info">Stack %1$d/%2$d: %3$s() line %4$d</string>
     <string name="text_jump_to_start">Jump to start</string>
     <string name="text_keep_screen_on_when_in_foreground">Keep screen on when in foreground</string>
     <string name="text_key_alias">Alias</string>


### PR DESCRIPTION
## 功能说明

脚本运行出错时，可在错误调用堆栈帧间循环跳转，方便快速定位问题。

## 修改内容

- **CodeEditor.kt**: 添加 \StackFrame\ 数据类和堆栈帧管理方法
- **EditorView.kt**: 添加 \parseStackTrace\ 方法解析 Rhino 错误堆栈
- **EditorMenu.java**: 添加跳转到出错行菜单项处理
- **menu_editor.xml**: 添加菜单项
- **strings.xml**: 添加中英文字符串资源

## 使用方法

1. 运行脚本出错后，编辑器会自动跳转到错误行
2. 打开菜单：跳转 → 跳转到出错行
3. 每次点击在堆栈帧间循环跳转
4. Toast 显示当前帧信息：\堆栈 2/5: funcName() 行 42\

## 示例

当脚本出错时，错误信息如：
\\\
Error: test error
    at funcA (/script/test.js:10:5)
    at funcB (/script/test.js:20:3)
    at main (/script/test.js:30:1)
\\\

点击" 跳转到出错行\会在第10行、第20行、第30行之间循环跳转。 --base master