### PR TITLE
Fix ConcatReader.close() to close all readers on failure

### DIFF
--- a/app/src/main/java/com/stardust/io/ConcatReader.java
+++ b/app/src/main/java/com/stardust/io/ConcatReader.java
@@ -383,10 +383,17 @@ public class ConcatReader extends Reader {
     @Override
     public void close() throws IOException {
         if (closed) return;
+        IOException first = null;
         for (Reader reader : readerQueue) {
-            reader.close();
+            try {
+                reader.close();
+            } catch (IOException e) {
+                if (first == null) first = e;
+                else first.addSuppressed(e);
+            }
         }
         closed = true;
+        if (first != null) throw first;
     }
 
     /**

--- a/app/src/main/java/org/autojs/autojs/io/ConcatReader.java
+++ b/app/src/main/java/org/autojs/autojs/io/ConcatReader.java
@@ -381,10 +381,17 @@ public class ConcatReader extends Reader {
     @Override
     public void close() throws IOException {
         if (closed) return;
+        IOException first = null;
         for (Reader reader : readerQueue) {
-            reader.close();
+            try {
+                reader.close();
+            } catch (IOException e) {
+                if (first == null) first = e;
+                else first.addSuppressed(e);
+            }
         }
         closed = true;
+        if (first != null) throw first;
     }
 
     /**


### PR DESCRIPTION
This PR makes `ConcatReader.close()` exception-safe in both `com.stardust.io.ConcatReader` and `org.autojs.autojs.io.ConcatReader`.

**Problem**
If closing one underlying `Reader` throws an `IOException`, `close()` exits early and the remaining readers are never closed.

**Fix**
Close all readers in the queue, collect the first `IOException`, suppress subsequent close failures, and throw after cleanup is complete.
