### PR TITLE
Fix console color resource references and AutoJs singleton in LogBottomSheet

### DIFF
--- a/app/src/main/java/org/autojs/autojs/ui/log/LogBottomSheet.kt
+++ b/app/src/main/java/org/autojs/autojs/ui/log/LogBottomSheet.kt
@@ -79,26 +79,24 @@ class LogBottomSheet : BottomSheetDialogFragment() {
         }
 
         // Setup ConsoleView with global console
-        val autoJs = AutoJs.getInstance()
-        if (autoJs != null) {
-            binding.console.setConsole(autoJs.globalConsole)
-            
-            // Hide input container (not needed in bottom sheet)
-            binding.console.findViewById<View>(R.id.input_container)?.visibility = View.GONE
-            
-            // Enable clickable stack frame links (only in bottom sheet, not in LogActivity)
-            binding.console.setEnableStackFrameLinks(true)
-            
-            // Set up clickable stack frame listener
-            binding.console.setOnStackFrameClickListener { fileName, lineNumber, columnNumber ->
-                mStackFrameClickListener?.onStackFrameClick(fileName, lineNumber, columnNumber)
-                dismiss()
-            }
+        val autoJs = AutoJs.instance
+        binding.console.setConsole(autoJs.globalConsole)
+
+        // Hide input container (not needed in bottom sheet)
+        binding.console.findViewById<View>(R.id.input_container)?.visibility = View.GONE
+
+        // Enable clickable stack frame links (only in bottom sheet, not in LogActivity)
+        binding.console.setEnableStackFrameLinks(true)
+
+        // Set up clickable stack frame listener
+        binding.console.setOnStackFrameClickListener { fileName, lineNumber, columnNumber ->
+            mStackFrameClickListener?.onStackFrameClick(fileName, lineNumber, columnNumber)
+            dismiss()
         }
 
         // Clear button
         binding.btnClear.setOnClickListener {
-            AutoJs.getInstance()?.globalConsole?.clear()
+            AutoJs.instance.globalConsole.clear()
         }
 
         // Open full log activity button

--- a/app/src/main/res/layout/bottom_sheet_log.xml
+++ b/app/src/main/res/layout/bottom_sheet_log.xml
@@ -77,8 +77,8 @@
             android:id="@+id/console"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            app:color_debug="@color/console_debug"
-            app:color_verbose="@color/console_verbose"/>
+            app:color_debug="@color/console_view_debug"
+            app:color_verbose="@color/console_view_verbose"/>
 
     </FrameLayout>
 


### PR DESCRIPTION
Two small fixes in the log bottom sheet:

1. **XML layout**: Change `@color/console_debug` → `@color/console_view_debug` and `@color/console_verbose` → `@color/console_view_verbose` — the old names referenced colors that don't exist, causing the console to render with default colors.

2. **Kotlin**: Change `AutoJs.getInstance()` (nullable, null-guarded) to `AutoJs.instance` (non-null). The bottom sheet only opens from the main UI after AutoJs is initialized, so the null check was unnecessary defensive code — and the inner block was skipped entirely in practice.

Neither change is breaking. Tested on the fleet-profile fork build.

Thank you for maintaining this project — it's incredibly useful.