### PR TITLE
Fix: bounds-check drawer subtitle array access to prevent crash

### DIFF
--- a/app/src/main/java/org/autojs/autojs/ui/main/drawer/DrawerFragment.kt
+++ b/app/src/main/java/org/autojs/autojs/ui/main/drawer/DrawerFragment.kt
@@ -586,8 +586,13 @@ open class DrawerFragment : Fragment() {
                 override fun refreshSubtitle(aimState: Boolean) {
                     val oldSubtitle = mKeepScreenOnWhenInForegroundItem.subtitle
                     val aimSubtitle = if (ViewUtils.isKeepScreenOnWhenInForegroundDisabled) null else {
-                        val i = resources.getStringArray(R.array.keys_keep_screen_on_when_in_foreground).indexOf(Pref.keyKeepScreenOnWhenInForeground)
-                        resources.getStringArray(R.array.values_keep_screen_on_when_in_foreground)[i]
+                        val keys = resources.getStringArray(R.array.keys_keep_screen_on_when_in_foreground)
+                        val i = keys.indexOf(Pref.keyKeepScreenOnWhenInForeground)
+                        if (i in keys.indices) {
+                            resources.getStringArray(R.array.values_keep_screen_on_when_in_foreground)[i]
+                        } else {
+                            null
+                        }
                     }
                     if (mKeepScreenOnWhenInForegroundItem.subtitle != aimSubtitle) {
                         mKeepScreenOnWhenInForegroundItem.subtitle = aimSubtitle


### PR DESCRIPTION
When a SharedPreference key stored for `keep_screen_on_when_in_foreground` does not match any entry in `R.array.keys_keep_screen_on_when_in_foreground`, `indexOf()` returns -1. The subsequent array access at that index throws `ArrayIndexOutOfBoundsException`, crashing `DrawerFragment.onResume`.

This is a pre-existing bug that any code path writing an unrecognized value to the preference can trigger (not just external callers — even a fresh install picking up a default that doesn't match the keys array could hit it).

**Fix:** Add a bounds check (`if (i in keys.indices)`) before the array access, showing no subtitle when the key isn't found. This guards the single affected `refreshSubtitle` override in DrawerFragment.

One file changed, 7 lines added.

Thank you again for your work on AutoJs6!